### PR TITLE
Update wirehair subtree, and fix handling of `WirehairCodec` ptr across the ffi boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(wirehair)
 
+
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
@@ -10,6 +11,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 option(MARCH_NATIVE "Use -march=native option" ON)
+option(BUILD_TESTS "build testsuite" ON)
 
 set(LIB_SOURCE_FILES
         wirehair.cpp
@@ -79,22 +81,24 @@ set_target_properties(wirehair PROPERTIES VERSION 2)
 set_target_properties(wirehair PROPERTIES SOVERSION 2)
 target_include_directories(wirehair PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-add_executable(unit_test ${UNIT_TEST_SOURCE_FILES})
-target_link_libraries(unit_test wirehair)
+if (BUILD_TESTS)
+    add_executable(unit_test ${UNIT_TEST_SOURCE_FILES})
+    target_link_libraries(unit_test wirehair)
 
-add_executable(gen_small_dseeds ${GEN_SMALL_DSEEDS})
-target_link_libraries(gen_small_dseeds wirehair)
+    add_executable(gen_small_dseeds ${GEN_SMALL_DSEEDS})
+    target_link_libraries(gen_small_dseeds wirehair)
 
-add_executable(gen_peel_seeds ${GEN_PEEL_SEEDS})
-target_link_libraries(gen_peel_seeds wirehair)
+    add_executable(gen_peel_seeds ${GEN_PEEL_SEEDS})
+    target_link_libraries(gen_peel_seeds wirehair)
 
-add_executable(gen_most_dseeds ${GEN_MOST_DSEEDS})
-target_link_libraries(gen_most_dseeds wirehair)
+    add_executable(gen_most_dseeds ${GEN_MOST_DSEEDS})
+    target_link_libraries(gen_most_dseeds wirehair)
 
-add_executable(gen_dcounts ${GEN_DCOUNTS})
-target_link_libraries(gen_dcounts wirehair)
+    add_executable(gen_dcounts ${GEN_DCOUNTS})
+    target_link_libraries(gen_dcounts wirehair)
 
-add_executable(gen_tables ${GEN_TABLES})
+    add_executable(gen_tables ${GEN_TABLES})
+endif()
 
 include(GNUInstallDirs)
 

--- a/include/wirehair/wirehair.h
+++ b/include/wirehair/wirehair.h
@@ -243,7 +243,7 @@ WIREHAIR_EXPORT WirehairResult wirehair_decode(
 );
 
 /**
-    wirehair_reconstruct()
+    wirehair_recover()
 
     Reconstruct the message after reading is complete.
 

--- a/pywirehair/decoder.py
+++ b/pywirehair/decoder.py
@@ -7,7 +7,9 @@ from .wirehair import wirehair
 class decoder:
     def __init__(self, msg_size, packet_size):
         self.msg_size = msg_size
-        self._did = wirehair().wirehair_decoder_create(0, ctypes.c_uint64(msg_size), ctypes.c_uint32(packet_size))
+        # WirehairCodec is a pointer, and we need to make that explicit
+        wirehair().wirehair_decoder_create.restype = ctypes.c_void_p
+        self._did = wirehair().wirehair_decoder_create(None, ctypes.c_uint64(msg_size), ctypes.c_uint32(packet_size))
         self._result = None
         self._seen_blocks = set()
 
@@ -21,7 +23,7 @@ class decoder:
 
         buffer = (ctypes.c_uint8 * len(buffer)).from_buffer_copy(buffer)
         res = wirehair().wirehair_decode(
-            self._did,
+            ctypes.c_void_p(self._did),
             ctypes.c_uint(block_id),
             ctypes.byref(buffer),
             len(buffer)
@@ -35,7 +37,7 @@ class decoder:
     def _recover(self):
         dec = (ctypes.c_uint8 * self.msg_size)()
         res = wirehair().wirehair_recover(
-            self._did,
+            ctypes.c_void_p(self._did),
             ctypes.byref(dec),
             ctypes.c_uint64(self.msg_size)
         )

--- a/pywirehair/encoder.py
+++ b/pywirehair/encoder.py
@@ -8,15 +8,17 @@ class encoder:
     def __init__(self, msg, packet_size):
         self.msg = (ctypes.c_uint8 * len(msg)).from_buffer_copy(msg)
         self.packet_size = packet_size
+        # WirehairCodec is a pointer, and we need to make that explicit
+        wirehair().wirehair_encoder_create.restype = ctypes.c_void_p
         self._eid = wirehair().wirehair_encoder_create(
-            0, ctypes.byref(self.msg), ctypes.c_uint64(len(self.msg)), ctypes.c_uint32(packet_size)
+            None, ctypes.byref(self.msg), ctypes.c_uint64(len(self.msg)), ctypes.c_uint32(packet_size)
         )
         self._buff = (ctypes.c_uint8 * packet_size)()
 
     def encode(self, block_id):
         writelen = ctypes.c_uint32(0)
         res = wirehair().wirehair_encode(
-            self._eid, ctypes.c_uint(block_id), ctypes.byref(self._buff), ctypes.c_uint32(self.packet_size),
+            ctypes.c_void_p(self._eid), ctypes.c_uint(block_id), ctypes.byref(self._buff), ctypes.c_uint32(self.packet_size),
             ctypes.byref(writelen)
         )
         if res != Wirehair_Success:

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     version=read_version(),
 
     author='Stephen Zimmerman',
-    author_email='sz@galacticicecube.com',
+    author_email='sz@recv.cc',
     description='Python wrapper for wirehair FEC',
     long_description=open("README.md").read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The explicit `ctypes.c_void_p`s fix a segfault on ubuntu 22.04.